### PR TITLE
Update gatsby-config.js

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -11,7 +11,7 @@ module.exports = {
     {
       resolve: `gatsby-source-datocms`,
       options: {
-        apiToken: process.env.DATO_API_TOKEN,
+        apiToken: process.env.DATOCMS_PROJECT_READ_ONLY_TOKEN,
       },
     },
   ],


### PR DESCRIPTION
Change `DATO_API_TOKEN` to `DATOCMS_PROJECT_READ_ONLY_TOKEN` so they don't need to update it to work with Gatsby Cloud.